### PR TITLE
Updated tests to add username field on successful JWT validation

### DIFF
--- a/__tests__/supertest.js
+++ b/__tests__/supertest.js
@@ -154,7 +154,7 @@ describe('can log in successfully', () => {
       .get('/api/auth/validate')
       .expect('Content-Type', /json/)
       .expect((response) => {
-        expect(response.body).toEqual({ message: 'User successfully validated.' });
+        expect(response.body).toEqual({ message: 'User successfully validated.', username: 'testuser' });
       })
       .expect(200, done);
   });
@@ -274,7 +274,7 @@ describe('can register successfully', () => {
       .get('/api/auth/validate')
       .expect('Content-Type', /json/)
       .expect((response) => {
-        expect(response.body).toEqual({ message: 'User successfully validated.' });
+        expect(response.body).toEqual({ message: 'User successfully validated.', username: 'newuser' });
       })
       .expect(200, done);
   });

--- a/server/modules/api/auth/controller.ts
+++ b/server/modules/api/auth/controller.ts
@@ -221,6 +221,8 @@ const controller: AuthController = {
         });
       }
 
+      res.locals.username = decoded.username;
+
       return next();
     });
     // OUTSIDE JWT

--- a/server/modules/api/auth/route.ts
+++ b/server/modules/api/auth/route.ts
@@ -10,7 +10,7 @@ router.post('/register', controller.validateFields, controller.doesUsernameExist
 
 router.post('/login', controller.validateFields, controller.doesUsernameExist, controller.doesEmailExist, controller.checkLogin, controller.createSession, (req, res) => res.status(200).json({ message: 'Log in successful.' }));
 
-router.get('/validate', controller.validateUser, (req, res) => res.status(200).json({ message: 'User successfully validated.' }));
+router.get('/validate', controller.validateUser, (req, res) => res.status(200).json({ message: 'User successfully validated.', username: res.locals.username }));
 
 router.post('/logout', controller.logout, (req, res) => res.status(200).json({ message: 'Successfully logged out.' }));
 


### PR DESCRIPTION
Enable server-wide username retrieval through http call instead of cross-referencing controllers.